### PR TITLE
Add Hub release notes for May–Jun 2026

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -32,12 +32,6 @@ Fixed several audit log issues: the *Jump to latest* button now reliably reloads
 
 [#_2026_05_26]
 
-=== Guided Synapse deployment
-
-[#_guided_synapse_deployment]
-
-Deploying xref:synapse.adoc[Synapse] is now guided by a step-by-step modal that produces the configuration and commands for your chosen method — Docker, Docker Compose, Helm, or Kubernetes — including the licence key and credentials. The instructions are tailored to both managed Cerbos Hub and on-premises deployments.
-
 === Navigation reflects your permissions
 
 [#_navigation_reflects_your_permissions]

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -1,5 +1,55 @@
 = Release notes
 
+== 2026-06-18
+
+[#_2026_06_18]
+
+=== Output errors in test results, the playground, and audit logs
+
+[#_output_errors_surfaced]
+
+Policy output errors now show up wherever you inspect a decision: in test results, in the playground's Explore tab, and in the audit log entry slideout. When an output expression fails to evaluate you see the error inline instead of an empty result, which makes output blocks much easier to debug.
+
+=== Insights and Usage access aligned with audit logs
+
+[#_insights_usage_access]
+
+Access to the xref:insights.adoc[Insights] and Usage pages now follows the same permissions as audit logs, so they are available to workspace Owners and Analysts. This keeps every view of your decision data governed by one consistent permission.
+
+=== Wider audit logs and Insights tables
+
+[#_wider_audit_logs_and_insights_tables]
+
+The audit logs page no longer caps its width, so tables can use the full width of large displays. Tables on the Insights page now scroll horizontally as well, so long action names are no longer truncated.
+
+=== Audit log fixes
+
+[#_audit_log_fixes]
+
+Fixed several audit log issues: the *Jump to latest* button now reliably reloads the most recent entries, scroll position is kept when paging back through earlier entries, and the table no longer ends up empty after a filter is added and then removed.
+
+== 2026-05-26
+
+[#_2026_05_26]
+
+=== Guided Synapse deployment
+
+[#_guided_synapse_deployment]
+
+Deploying xref:synapse.adoc[Synapse] is now guided by a step-by-step modal that produces the configuration and commands for your chosen method — Docker, Docker Compose, Helm, or Kubernetes — including the licence key and credentials. The instructions are tailored to both managed Cerbos Hub and on-premises deployments.
+
+=== Navigation reflects your permissions
+
+[#_navigation_reflects_your_permissions]
+
+Organization and workspace navigation now hides entries for areas you do not have access to, so the menus show only the pages you can actually open.
+
+=== Correct policy version in audit logs
+
+[#_correct_policy_version_in_audit_logs]
+
+Fixed the policy version shown on audit log entries, which was being read from the wrong field in the decision summaries data. Entries now display the correct policy version.
+
 == 2026-05-20
 
 [#_2026_05_20]


### PR DESCRIPTION
Adds Cerbos Hub release notes for the period since the last documented date (2026-05-20), generated from `production/v*` tags in the spitfire repo.

## New sections

### 2026-06-18
- **Output errors in test results, the playground, and audit logs** — output evaluation errors now surfaced inline (#4594)
- **Insights and Usage access aligned with audit logs** — pages now gated to workspace Owners/Analysts (#4569)
- **Wider audit logs and Insights tables** — removed width cap, horizontal scroll for long action names (#4666)
- **Audit log fixes** — Jump to latest, scroll restoration, empty-after-filter bug (#4621)

### 2026-05-26
- **Guided Synapse deployment** — step-by-step deployment modal for Docker/Compose/Helm/Kubernetes, managed + on-prem (#4557)
- **Navigation reflects your permissions** — nav hides areas you can't access (#4568)
- **Correct policy version in audit logs** — fixed wrong field extraction (#4555)

## Excluded
- Policy matrix view work (#4552, #4658) — the matrix UI was hidden before release (#4662)
- Dependency bumps, CI/CD, infra, design-system-v2 internals, e2e, ui-next deploy scaffolding
- HEAD/unreleased commits contained no user-facing changes (CI, deps, ui-next beta behind a toggle)