### PR TITLE
Add Hub release notes for the effect matrix view (2026-06-30)

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -10,6 +10,12 @@
 
 The Policies tab of a xref:deployments.adoc[deployment] now has a *Source* / *Effect matrix* toggle. The effect matrix lays out a resource's roles and actions as a grid and shows, at a glance, whether each role-and-action combination is allowed, denied, or conditional in the deployed bundle, so you can review effective permissions without reading through every policy file. Cells also flag where a wildcard rule (such as `*` or `foo:*`) widens the match, and you can filter the grid and drill into a cell to see the underlying rules.
 
+=== Distribution licence keys for Cerbos Synapse
+
+[#_distribution_licence_keys]
+
+Organizations with xref:synapse.adoc[Cerbos Synapse] access can now manage their distribution licence key from organization settings. A licence key authenticates your Synapse instances with the Cerbos distribution registry (`distribution.cerbos.cloud`) so they can pull updates, used as the password for `docker login`. You can generate a key, rotate it with a configurable grace period (up to 12 hours) during which the previous key keeps working, and revoke it immediately. Synapse is enabled per organization; https://cerbos.dev/contact[contact the Cerbos team] for access.
+
 == 2026-06-18
 
 [#_2026_06_18]

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -1,5 +1,15 @@
 = Release notes
 
+== 2026-06-30
+
+[#_2026_06_30]
+
+=== Effect matrix view for deployment policies
+
+[#_effect_matrix_view]
+
+The Policies tab of a xref:deployments.adoc[deployment] now has a *Source* / *Effect matrix* toggle. The effect matrix lays out a resource's roles and actions as a grid and shows, at a glance, whether each role-and-action combination is allowed, denied, or conditional in the deployed bundle, so you can review effective permissions without reading through every policy file. Cells also flag where a wildcard rule (such as `*` or `foo:*`) widens the match, and you can filter the grid and drill into a cell to see the underlying rules.
+
 == 2026-06-18
 
 [#_2026_06_18]

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -14,7 +14,7 @@ The Policies tab of a xref:deployments.adoc[deployment] now has a *Source* / *Ef
 
 [#_distribution_licence_keys]
 
-Organizations with xref:synapse.adoc[Cerbos Synapse] access can now manage their distribution licence key from organization settings. A licence key authenticates your Synapse instances with the Cerbos distribution registry (`distribution.cerbos.cloud`) so they can pull updates, used as the password for `docker login`. You can generate a key, rotate it with a configurable grace period (up to 12 hours) during which the previous key keeps working, and revoke it immediately. Synapse is enabled per organization; https://cerbos.dev/contact[contact the Cerbos team] for access.
+Organizations with xref:synapse.adoc[Cerbos Synapse] access can now manage their distribution licence key from organization settings. A licence key authenticates your Synapse instances with the Cerbos distribution registry so they can pull updates, used as the password for `docker login` against the registry endpoint shown in Hub. You can generate a key, rotate it with a configurable grace period (up to 12 hours) during which the previous key keeps working, and revoke it immediately. Synapse is enabled per organization; https://cerbos.dev/contact[contact the Cerbos team] for access.
 
 == 2026-06-18
 


### PR DESCRIPTION
## Summary

Adds Cerbos Hub release-notes entries for user-facing changes merged since the last entry (`2026-06-18`), covering production tags up to `production/v26.06.30-801`.

### Included

- **Effect matrix view for deployment policies** — the deployment Policies tab now has a *Source* / *Effect matrix* toggle that visualises each resource's roles × actions grid with allow/deny/conditional effects and wildcard-match hints. Hidden during development (#4662) and enabled in production via spitfire [#4714](https://github.com/cerbos/spitfire/pull/4714) (finalised in [#4712](https://github.com/cerbos/spitfire/pull/4712), wildcard hints in [#4709](https://github.com/cerbos/spitfire/pull/4709)). Verified live: the enabling commit uncomments the view-mode `Switch` and no later commit reverts it.
- **Distribution licence keys for Cerbos Synapse** — organizations with Synapse access can generate, rotate (with a grace period of up to 12h), and revoke a distribution licence key from org settings, used to authenticate Synapse instances against `distribution.cerbos.cloud` (`docker login`). From spitfire [#4713](https://github.com/cerbos/spitfire/pull/4713). Synapse is gated behind the `synapse` prd flag and **enabled per organization** (rolled out customer-by-customer), so this is documented as available-on-request rather than GA — included at maintainer's request since it is being switched on per customer.

### Excluded (notable but not live) — please sanity-check

- **ui-next** (spitfire [#4674](https://github.com/cerbos/spitfire/pull/4674), [#4687](https://github.com/cerbos/spitfire/pull/4687)) — the next-gen UI is deployed but toggled only via the staging environment badge ("stg/ui-next"); not exposed in production.
- **Organization-level API keys authz** (spitfire [#4694](https://github.com/cerbos/spitfire/pull/4694)) — backend "v3 policy set" groundwork; the PR notes workspace API keys are "soon to move to organization level", i.e. not yet a live user-facing capability.
- Everything else in the range was dependency/infra/CI, design-system internals, query optimisations, and audit-log internals.

### Docs follow-up

`cerbos/cloud-docs` has GitHub issues disabled, so docs gaps could not be filed as issues. Two pages would benefit from expansion: `deployments.adoc` (the effect matrix view) and `synapse.adoc` (the distribution licence / registry auth flow).