### PR TITLE
Document Synapse distribution licence key management

### DIFF
--- a/modules/ROOT/pages/synapse.adoc
+++ b/modules/ROOT/pages/synapse.adoc
@@ -68,6 +68,31 @@ Data sources can connect to graph databases (Neo4j, Amazon Neptune) to resolve r
 
 Synapse connects to Cerbos Hub for policy distribution and audit logging. Hub pushes policy bundles to the in-process PDP, and decision logs stream back to Hub for audit and observability. The same deployment, policy store, and monitoring workflows used for standalone PDPs apply to Synapse instances.
 
+== Distribution licence
+
+Synapse images and updates are served from the Cerbos distribution registry at `distribution.cerbos.cloud`. Each organization with Synapse access authenticates to the registry with a *distribution licence key*, which you manage from your organization settings in Cerbos Hub.
+
+=== Issuing and using a key
+
+Generate a distribution licence key from the *Distribution licence* section of your organization settings. The key is used as the password when authenticating to the registry — the username is your organization ID:
+
+[source,bash]
+----
+docker login distribution.cerbos.cloud \
+  --username=<your-organization-id> \
+  --password=<distribution-licence-key>
+----
+
+Treat the key like a secret. Anyone who needs to pull Synapse images — your CI pipeline, container runtime, or local environment — uses it to authenticate. A key may be issued with or without an expiry; if it has an expiry, the registry stops accepting it after that time.
+
+=== Rotating a key
+
+Rotating issues a new key while keeping the current one valid for a configurable grace period (up to 12 hours), so you can roll the new key out to your Synapse instances before the old one stops working. Set the grace period to zero to revoke the previous key immediately. Already-running instances are unaffected during the grace period; only new registry pulls require the new key once the old one is revoked.
+
+=== Revoking a key
+
+Revoking invalidates the current key immediately and cannot be undone. Running Synapse instances keep working, but any new registry pull — for example pulling an updated image — fails until a new key is issued and configured. Revoke a key if you believe it has been exposed, then generate a replacement.
+
 == Availability
 
-Cerbos Synapse is available as part of the Cerbos platform. https://cerbos.dev/contact[Contact the Cerbos team] for access and deployment guidance.
+Cerbos Synapse is available as part of the Cerbos platform, and is enabled per organization. https://cerbos.dev/contact[Contact the Cerbos team] for access and deployment guidance.

--- a/modules/ROOT/pages/synapse.adoc
+++ b/modules/ROOT/pages/synapse.adoc
@@ -70,7 +70,7 @@ Synapse connects to Cerbos Hub for policy distribution and audit logging. Hub pu
 
 == Distribution licence
 
-Synapse images and updates are served from the Cerbos distribution registry at `distribution.cerbos.cloud`. Each organization with Synapse access authenticates to the registry with a *distribution licence key*, which you manage from your organization settings in Cerbos Hub.
+Synapse images and updates are served from the Cerbos distribution registry. Each organization with Synapse access authenticates to the registry with a *distribution licence key*, which you manage from your organization settings in Cerbos Hub. Your specific registry endpoint is shown alongside the licence key in Hub; use that value in place of `<distribution-registry>` below.
 
 === Issuing and using a key
 
@@ -78,7 +78,7 @@ Generate a distribution licence key from the *Distribution licence* section of y
 
 [source,bash]
 ----
-docker login distribution.cerbos.cloud \
+docker login <distribution-registry> \
   --username=<your-organization-id> \
   --password=<distribution-licence-key>
 ----


### PR DESCRIPTION
## Summary

Adds a **Distribution licence** section to `synapse.adoc` covering the licence-key management flow that organizations with Cerbos Synapse access now have in their organization settings. The page previously described Synapse's architecture but not how instances authenticate to the distribution registry.

### What's added

- **Distribution licence** intro — keys authenticate to `distribution.cerbos.cloud`, managed from org settings
- **Issuing and using a key** — including the `docker login` command (username = organization ID, password = key) and the secret-handling / expiry notes
- **Rotating a key** — new key issued with a configurable grace period (up to 12h); set to zero to revoke immediately
- **Revoking a key** — immediate, irreversible; running instances keep working but new pulls fail until a new key is configured

Also notes in **Availability** that Synapse is enabled per organization.

### Source

spitfire [#4713](https://github.com/cerbos/spitfire/pull/4713) (Licence key management improvements). Synapse is gated behind the `synapse` prd flag and enabled customer-by-customer. Release-notes entry: cerbos/cloud-docs#47.