### PR TITLE
Add Hub release notes for workspace issues and audit log fix (2026-07-13)

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -1,5 +1,25 @@
 = Release notes
 
+== 2026-07-13
+
+[#_2026_07_13]
+
+=== Issues surfaced for your workspaces
+
+[#_workspace_issues]
+
+The issues bar in Cerbos Hub now flags problems with your deployment workspaces, so you can catch and fix them without digging through settings. It surfaces blocked API keys, deployments that have been mapped to a new store but have not activated a new build for 15 minutes, and stores that are failing to sync with GitHub. Each issue links through to the relevant page for the details. The separate issues page has been removed, since the issues bar already appears on every page.
+
+== 2026-07-08
+
+[#_2026_07_08]
+
+=== Audit log entries with empty values now display correctly
+
+[#_audit_log_empty_values]
+
+Fixed an issue where an audit log entry containing an empty (null) value could fail to load. These entries now render correctly, so no decision is missing from your audit trail.
+
 == 2026-06-30
 
 [#_2026_06_30]

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -8,7 +8,7 @@
 
 [#_workspace_issues]
 
-The issues bar in Cerbos Hub now flags problems with your deployment workspaces, so you can catch and fix them without digging through settings. It surfaces blocked API keys, deployments that have been mapped to a new store but have not activated a new build for 15 minutes, and stores that are failing to sync with GitHub. Each issue links through to the relevant page for the details. The separate issues page has been removed, since the issues bar already appears on every page.
+The issues bar in Cerbos Hub now flags problems with your deployment workspaces, so you can catch and fix them without digging through settings. It surfaces blocked API keys, deployments that have been mapped to a new store but have not activated a new build for 15 minutes, and stores that are failing to sync with GitHub. Each issue links through to the relevant page for the details.
 
 == 2026-07-08
 


### PR DESCRIPTION
Adds Cerbos Hub release notes covering user-facing, production changes since the last documented date (2026-06-30).

## New entries

- **2026-07-13 — Issues surfaced for your workspaces**: the issues bar now flags problems with deployment workspaces (blocked API keys; deployments mapped to a new store with no build activated for 15 minutes; stores failing to sync with GitHub), each linking to the relevant page. The standalone issues page was removed. Source: cerbos/spitfire#4776 (merged 2026-07-10, on `main`; pending the next production tag at generation time — please sanity-check it is deployed before merging).
- **2026-07-08 — Audit log entries with empty values now display correctly**: fixed audit log entries with a null value failing to load. Source: cerbos/spitfire#4765 (released in `production/v26.07.08-1604`).

## Excluded / not documented (for reviewer sanity-check)

- **End-of-trial expiry warning UI** (spitfire#4760): only *adds an organization* to the existing `hub-trial-expiry-warning` segment rollout — not a new feature in this window. The flag is `enabled: false` globally, live only for the trial-expiring-orgs segment.
- **Cerbos Synapse org enablements** (spitfire#4779, #4774, #4770): per-org additions to the `synapse` segment rollout. Synapse remains gated (`enabled: false` globally, live for a 6-org segment) and is already documented.
- **Audit logs export — GCS bucket & credentials** (spitfire#4766): infrastructure groundwork only; the export feature is not yet user-facing/live. Excluded until it ships.
- Everything else in range was dependency updates, internal dashboards/observability, CI fixes, test additions, and internal refactors (e.g. remove v2 policies, workspace cleanup).

## Note on docs issues

The scheduled task also asks to file follow-up documentation issues on `cerbos/cloud-docs`, but **issues are disabled** on that repository, so none could be filed. The workspace-issues change (spitfire#4776) is the one item that could warrant more than a changelog line (a note on the deployments page about the issues bar / blocked API keys / sync failures) — flagging here instead.
