### PR TITLE
Add Hub release notes and docs for GitHub egress IPs (2026-07-27)

### DIFF
--- a/modules/ROOT/pages/policy-stores-git-github.adoc
+++ b/modules/ROOT/pages/policy-stores-git-github.adoc
@@ -21,7 +21,22 @@ To set up the GitHub integration, follow these steps:
   image:policy_store_github_connection_setup.png[alt="GitHub connection setup",role="center-img"]
 7. Click "Save" to complete the setup.
 
-NOTE: If you have an IP allow list for your GitHub organization, add `34.65.34.39` and `34.65.140.62` to allow Cerbos Hub to access your repository.
+== GitHub organization IP allow lists
+
+If your GitHub organization has an IP allow list enabled, you must permit the addresses Cerbos Hub connects from. Otherwise connecting the repository fails, and any store that is already connected stops syncing, with GitHub rejecting the request with a `403` response.
+
+The current addresses are `34.65.34.39` and `34.65.140.62`. Cerbos Hub also shows them while you connect a repository — both when installing the GitHub App and when choosing the repository — so you can copy them without leaving the flow.
+
+To manage your allow list automatically, fetch the addresses from https://hub.cerbos.cloud/meta[hub.cerbos.cloud/meta], which returns them as an `egressIps` array:
+
+[source,json]
+----
+{"egressIps":["34.65.34.39","34.65.140.62"]}
+----
+
+TIP: Treat that endpoint as the source of truth rather than hard-coding the addresses into your own configuration.
+
+NOTE: This allow list is unrelated to the xref:deployments-epdp-rules.adoc#_ip_allowlist[IP allowlist on an ePDP rule], which controls who may download embedded PDP bundles from Cerbos Hub.
 
 == Syncing a subdirectory
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -1,5 +1,15 @@
 = Release notes
 
+== 2026-07-27
+
+[#_2026_07_27]
+
+=== Cerbos Hub egress IP addresses shown when connecting a GitHub repository
+
+[#_github_egress_ips]
+
+If your GitHub organization restricts access with an IP allow list, the xref:policy-stores-git-github.adoc[GitHub connection flow] now tells you which IP addresses Cerbos Hub connects from, so you can add them without leaving the wizard. The addresses are shown both when installing the GitHub App and when picking a repository, which means you see them even if the app is already installed. They are also published in machine-readable form at https://hub.cerbos.cloud/meta[hub.cerbos.cloud/meta], so you can keep your allow list up to date automatically.
+
 == 2026-07-16
 
 [#_2026_07_16]

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -8,7 +8,7 @@
 
 [#_github_egress_ips]
 
-If your GitHub organization restricts access with an IP allow list, the xref:policy-stores-git-github.adoc[GitHub connection flow] now tells you which IP addresses Cerbos Hub connects from, so you can add them without leaving the wizard. The addresses are shown both when installing the GitHub App and when picking a repository, which means you see them even if the app is already installed. They are also published in machine-readable form at https://hub.cerbos.cloud/meta[hub.cerbos.cloud/meta], so you can keep your allow list up to date automatically.
+If your GitHub organization restricts access with an IP allow list, the xref:policy-stores-git-github.adoc#_github_organization_ip_allow_lists[GitHub connection flow] now tells you which IP addresses Cerbos Hub connects from, so you can add them without leaving the wizard. The addresses are shown both when installing the GitHub App and when picking a repository, which means you see them even if the app is already installed. They are also published in machine-readable form at https://hub.cerbos.cloud/meta[hub.cerbos.cloud/meta], so you can keep your allow list up to date automatically.
 
 == 2026-07-16
 

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -123,6 +123,14 @@ PDP crashed before sync:: Logs are periodically synced to Cerbos Hub. If the PDP
 
 == GitHub integration issues
 
+=== Repository access blocked by an organization IP allow list
+
+*Symptoms*: Connecting a repository fails, or a connected store stops syncing, and GitHub rejects the request with a `403` mentioning that your organization has an IP allow list enabled.
+
+*Cause and solution*: Cerbos Hub connects to GitHub from a fixed set of addresses, which your organization's allow list must permit. Add them as described in xref:policy-stores-git-github.adoc#_github_organization_ip_allow_lists[GitHub organization IP allow lists], or fetch them from https://hub.cerbos.cloud/meta[hub.cerbos.cloud/meta] if you manage the allow list automatically.
+
+NOTE: This is a different setting from the ePDP rule allowlist covered under <<_bundle_fetch_fails_in_browser,Bundle fetch fails in browser>>. That one governs who may download bundles from Cerbos Hub; this one governs whether Cerbos Hub may reach your repository.
+
 === Builds aren't triggered when multiple tags are pushed
 
 GitHub has a link:https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push[known limitation] where connected apps like Cerbos Hub won't receive notifications for repository changes if more than three tags are pushed simultaneously. To avoid this issue, limit the maximum number of references pushed at once to three. See the link:https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-push-policy-for-your-repository#limiting-how-many-branches-and-tags-can-be-updated-in-a-single-push[GitHub documentation] for configuration details.


### PR DESCRIPTION
Adds a `2026-07-27` entry to the Hub release notes for the one user-facing change that went live in the latest production release, plus the supporting documentation for it (see cerbos/cerbos-private#2002).

## Changes

**Release notes** (`release-notes.adoc`) — new `2026-07-27` entry: Cerbos Hub egress IP addresses are now shown when connecting a GitHub repository.

**GitHub store page** (`policy-stores-git-github.adoc`) — replaces the one-line NOTE that hard-coded the egress IPs with a `GitHub organization IP allow lists` section covering the failure mode (GitHub `403`), the current addresses, the fact that Hub now shows them inline during the connect flow, and `https://hub.cerbos.cloud/meta` as the machine-readable source of truth. Verified live: that endpoint returns `{"egressIps":["34.65.34.39","34.65.140.62"]}`.

**Troubleshooting** (`troubleshooting.adoc`) — new entry under GitHub integration issues for a connection or sync blocked by an organization IP allow list, cross-referenced to the section above. Both pages note that this is a different setting from the ePDP rule IP allowlist, which is easy to confuse.
