### PR TITLE
Add Hub release notes for audit log exports and playground diagnostics (2026-08-11)

### DIFF
--- a/modules/ROOT/pages/audit-log-collection.adoc
+++ b/modules/ROOT/pages/audit-log-collection.adoc
@@ -127,6 +127,53 @@ The access logs are records of all the API requests received by the Cerbos PDP. 
 
 You can filter the logs by a particular PDP and a time range.
 
+== Exporting logs
+
+Decision and access logs can be exported from Cerbos Hub as files, for long-term archiving or for analysis in your own tooling. Exports are encrypted before they leave Cerbos Hub, so only you can read them.
+
+NOTE: Exporting requires the `Owner` role in the workspace or the organization. See xref:user-management.adoc[User management] for the full permissions matrix. Exports are not available for xref:on-premises.adoc[on-premises deployments], where the audit log data already resides in your own infrastructure.
+
+=== Starting an export
+
+Apply the filters and time range you want on the _Decision logs_ or _Access logs_ tab, then click **Export**. The export dialog shows the filters that will be applied, so you can confirm you are exporting the entries you were looking at, and lets you adjust the time range before confirming. If you have not selected a time range, the export defaults to the last 24 hours.
+
+Exports are produced in the background. Click **Add to export queue** to start one, then follow its progress on the _Exports_ tab. You do not need to keep the page open.
+
+=== Encryption keys
+
+Every export is encrypted with https://age-encryption.org[age] before it is written to storage. You need the corresponding secret key to read the file afterwards.
+
+* **If you already have an age key pair**, paste the public portion (it begins with `age1`) into the *Public encryption key* field when starting the export.
+* **If you leave the field blank**, Cerbos Hub generates a key pair for you and displays it once, immediately after the export is queued. Copy both parts, or click **Download key pair** to save them as an `age.key` file in the format the `age` tools expect.
+
+WARNING: Cerbos Hub does not retain the secret key, and it cannot be recovered or reissued. If you lose it, the export cannot be decrypted and you will need to run a new one. Store it somewhere safe, such as your organization's secret manager.
+
+=== The Exports tab
+
+The _Exports_ tab lists every export requested in the workspace, showing the log type, who requested it, when it was created, when it expires, the public key it was encrypted for, and its status:
+
+* **In progress**: the export has been queued or is being generated. The list refreshes automatically while any export is in this state.
+* **Ready**: the export is complete. Click **Download** to retrieve the file.
+* **Failed**: the export could not be completed. Click **Retry** to reopen the export dialog with the same filters and time range already applied.
+* **Expired**: the file is past its retention period and is no longer available. Run a new export to obtain the same data.
+
+Expand a row to see the time range and filters the export was created with, the public key used to encrypt it, and the exact command needed to decrypt it.
+
+=== Downloading and decrypting
+
+The downloaded file is age-encrypted and gzip-compressed, and contains the exported entries as JSON Lines — one JSON object per log entry. To decrypt and read it, save your secret key as `age.key` and run:
+
+[source,sh]
+----
+age -d -i age.key <exported-file> | gunzip
+----
+
+Because the output is JSON Lines, it can be piped directly into tools such as `jq`, or loaded into a data warehouse or SIEM without further conversion.
+
+=== Retention
+
+Completed exports remain available to download for seven days from the time they were generated. After that, the file is deleted and the export is marked as expired. Expiry applies only to the exported file — the underlying audit log data is unaffected and continues to be retained according to your plan, so the export can be re-created as long as the entries are still within that retention period.
+
 == Masking sensitive fields
 
 You can define masks to filter out sensitive or personally identifiable information (PII) that might be included in the audit log entries. Masked fields are removed locally at the PDP and are never transmitted to Cerbos Hub.

--- a/modules/ROOT/pages/playground.adoc
+++ b/modules/ROOT/pages/playground.adoc
@@ -71,6 +71,12 @@ The panel displays:
 
 Click **+ Add action** to test additional actions, or **Create auxiliary data fixtures** to add test data for your evaluations.
 
+=== Schema validation
+
+If your policies reference xref:cerbos:policies:schemas.adoc[schemas], the principal and resource you select are validated against them when the request is evaluated. Any violation is reported in an alert directly beneath the relevant fixture selector, listing the attribute paths that failed and why. Validation problems with the request as a whole are reported the same way, above the list of actions.
+
+While a validation error is outstanding, every action is shown in an undetermined state rather than as `ALLOW` or `DENY`. This distinguishes a request that could not be meaningfully evaluated from one that was genuinely denied, which is easy to misread otherwise. Correct the fixture, or adjust the schema, and the effects are recalculated immediately.
+
 === Permissions matrix view
 
 The matrix view displays permission evaluation results in a comprehensive grid format, showing how policies affect different principal and resource combinations at a glance. This is useful for:
@@ -85,10 +91,24 @@ Toggle between the standard explore view and the matrix view using the view sele
 
 The bottom panel shows test execution results with two tabs:
 
-* **Problems**: Displays any syntax errors or validation issues in your policies.
+* **Problems**: Displays any syntax errors or compilation issues in your policies. See <<_problems,Problems>> below.
 * **Test results**: Shows the outcome of all policy tests. Filter by **Passed**, **Failed**, **Skipped**, or **Errored** to focus on specific results.
 
 Click on any test file to see detailed results. For failed tests, a side-by-side diff view highlights the differences between expected and actual outputs.
+
+=== Problems
+
+The Problems tab lists everything that prevented your policies from compiling, grouped by file. Each entry gives the kind of error, the line and column it occurred at, and a description of what went wrong. Click an entry to jump straight to that position in the editor, where the same errors are also marked inline on the offending lines.
+
+Diagnostics cover the full range of compilation failures, not just malformed YAML:
+
+* Invalid xref:cerbos:policies:conditions.adoc[condition expressions], including expressions that parse but fail to compile.
+* Undefined, redefined, cyclical, or invalidly named xref:cerbos:policies:variables.adoc#variables[variables] and xref:cerbos:policies:variables.adoc#constants[constants].
+* Unknown or ambiguous xref:cerbos:policies:derived_roles.adoc[derived roles].
+* Imports that cannot be resolved, and problems with xref:cerbos:policies:scoped_policies.adoc[scoped policies] and scope inheritance.
+* Invalid xref:cerbos:policies:schemas.adoc[schema] references, empty xref:cerbos:policies:outputs.adoc[outputs], and malformed resource rules.
+
+Where a problem relates to a documented policy feature, the entry links to the relevant page of the Cerbos policy documentation, so you can go from the error to the reference material without searching for it.
 
 == Execution traces
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -1,5 +1,17 @@
 = Release notes
 
+== 2026-08-11
+
+[#_2026_08_11]
+
+=== Export audit logs from Cerbos Hub
+
+[#_audit_log_exports]
+
+You can now take your decision and access logs out of Cerbos Hub for long-term archiving or analysis in your own tooling. Press *Export* on the xref:audit-log-collection.adoc#_accessing_the_logs[Audit logs] page and the export is queued in the background using the time range and filters you already have applied, so you get exactly the entries you were looking at. A new *Exports* tab lists every export with its status, the filters it used and its expiry date, and offers a download button as soon as it is ready. Exporting is available to workspace and organization Owners.
+
+Exports are encrypted with https://age-encryption.org[age] before they leave Cerbos Hub. You can supply your own public key, or let Cerbos Hub generate a key pair for you and save it when the export starts — the secret key is never retained by Cerbos Hub, so store it somewhere safe. Expanding a row on the Exports tab shows the exact command to decrypt and read the file, which contains your log entries as gzip-compressed JSON Lines. Completed exports remain available to download for seven days, and a failed export can be retried with the same filters in one click.
+
 == 2026-07-27
 
 [#_2026_07_27]

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -8,7 +8,7 @@
 
 [#_audit_log_exports]
 
-You can now take your decision and access logs out of Cerbos Hub for long-term archiving or analysis in your own tooling. Press *Export* on the xref:audit-log-collection.adoc#_accessing_the_logs[Audit logs] page and the export is queued in the background using the time range and filters you already have applied, so you get exactly the entries you were looking at. A new *Exports* tab lists every export with its status, the filters it used and its expiry date, and offers a download button as soon as it is ready. Exporting is available to workspace and organization Owners.
+You can now take your decision and access logs out of Cerbos Hub for long-term archiving or analysis in your own tooling. Press *Export* on the xref:audit-log-collection.adoc#_exporting_logs[Audit logs] page and the export is queued in the background using the time range and filters you already have applied, so you get exactly the entries you were looking at. A new *Exports* tab lists every export with its status, the filters it used and its expiry date, and offers a download button as soon as it is ready. Exporting is available to workspace and organization Owners.
 
 Exports are encrypted with https://age-encryption.org[age] before they leave Cerbos Hub. You can supply your own public key, or let Cerbos Hub generate a key pair for you and save it when the export starts — the secret key is never retained by Cerbos Hub, so store it somewhere safe. Expanding a row on the Exports tab shows the exact command to decrypt and read the file, which contains your log entries as gzip-compressed JSON Lines. Completed exports remain available to download for seven days, and a failed export can be retried with the same filters in one click.
 
@@ -16,13 +16,13 @@ Exports are encrypted with https://age-encryption.org[age] before they leave Cer
 
 [#_playground_compile_diagnostics]
 
-Compilation problems in a xref:playground.adoc[playground] are now reported where they actually occur. Each error is marked inline on the offending line in the editor, and the xref:playground.adoc#_test_results[Problems] panel shows its line and column alongside a fuller description, so you can click through to the exact source rather than hunting for it. Several classes of problem that were previously reported vaguely — or not at all — are now surfaced properly, including invalid expressions in conditions, undefined or redefined variables and constants, unknown and ambiguous derived roles, and problems with scopes and imports. Where a diagnostic relates to a documented concept, it links straight to the relevant Cerbos policy documentation.
+Compilation problems in a xref:playground.adoc[playground] are now reported where they actually occur. Each error is marked inline on the offending line in the editor, and the xref:playground.adoc#_problems[Problems] panel shows its line and column alongside a fuller description, so you can click through to the exact source rather than hunting for it. Several classes of problem that were previously reported vaguely — or not at all — are now surfaced properly, including invalid expressions in conditions, undefined or redefined variables and constants, unknown and ambiguous derived roles, and problems with scopes and imports. Where a diagnostic relates to a documented concept, it links straight to the relevant Cerbos policy documentation.
 
 === Schema validation errors shown in playgrounds
 
 [#_playground_schema_validation]
 
-If a principal or resource fixture does not satisfy the schema attached to your policy, the xref:playground.adoc#_explore_tab[Explore tab] now says so directly beneath the fixture selector. Previously a schema violation would quietly influence the outcome, leaving you to work out why a check did not behave as expected. Actions affected by the failure are left in an undetermined state until the error is resolved, making it clear that the result is a fixture problem rather than a policy decision, and validation errors on the request itself are reported the same way above the action results.
+If a principal or resource fixture does not satisfy the schema attached to your policy, the xref:playground.adoc#_schema_validation[Explore tab] now says so directly beneath the fixture selector. Previously a schema violation would quietly influence the outcome, leaving you to work out why a check did not behave as expected. Actions affected by the failure are left in an undetermined state until the error is resolved, making it clear that the result is a fixture problem rather than a policy decision, and validation errors on the request itself are reported the same way above the action results.
 
 == 2026-07-27
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -12,6 +12,18 @@ You can now take your decision and access logs out of Cerbos Hub for long-term a
 
 Exports are encrypted with https://age-encryption.org[age] before they leave Cerbos Hub. You can supply your own public key, or let Cerbos Hub generate a key pair for you and save it when the export starts — the secret key is never retained by Cerbos Hub, so store it somewhere safe. Expanding a row on the Exports tab shows the exact command to decrypt and read the file, which contains your log entries as gzip-compressed JSON Lines. Completed exports remain available to download for seven days, and a failed export can be retried with the same filters in one click.
 
+=== Clearer policy compilation errors in playgrounds
+
+[#_playground_compile_diagnostics]
+
+Compilation problems in a xref:playground.adoc[playground] are now reported where they actually occur. Each error is marked inline on the offending line in the editor, and the xref:playground.adoc#_test_results[Problems] panel shows its line and column alongside a fuller description, so you can click through to the exact source rather than hunting for it. Several classes of problem that were previously reported vaguely — or not at all — are now surfaced properly, including invalid expressions in conditions, undefined or redefined variables and constants, unknown and ambiguous derived roles, and problems with scopes and imports. Where a diagnostic relates to a documented concept, it links straight to the relevant Cerbos policy documentation.
+
+=== Schema validation errors shown in playgrounds
+
+[#_playground_schema_validation]
+
+If a principal or resource fixture does not satisfy the schema attached to your policy, the xref:playground.adoc#_explore_tab[Explore tab] now says so directly beneath the fixture selector. Previously a schema violation would quietly influence the outcome, leaving you to work out why a check did not behave as expected. Actions affected by the failure are left in an undetermined state until the error is resolved, making it clear that the result is a fixture problem rather than a policy decision, and validation errors on the request itself are reported the same way above the action results.
+
 == 2026-07-27
 
 [#_2026_07_27]

--- a/modules/ROOT/pages/user-management.adoc
+++ b/modules/ROOT/pages/user-management.adoc
@@ -120,6 +120,12 @@ Permissions assigned at the organization level are inherited by all workspaces. 
 |✅
 |❌
 
+|Export audit logs
+|✅
+|❌
+|❌
+|❌
+
 |Manage API keys
 |✅
 |✅


### PR DESCRIPTION
## 2026-08-11

### Export audit logs from Cerbos Hub

You can now take your decision and access logs out of Cerbos Hub for long-term archiving or analysis in your own tooling. Press **Export** on the Audit logs page and the export is queued in the background using the time range and filters you already have applied, so you get exactly the entries you were looking at. A new **Exports** tab lists every export with its status, the filters it used and its expiry date, and offers a download button as soon as it is ready. Exporting is available to workspace and organization Owners.

Exports are encrypted with [age](https://age-encryption.org) before they leave Cerbos Hub. You can supply your own public key, or let Cerbos Hub generate a key pair for you and save it when the export starts — the secret key is never retained by Cerbos Hub, so store it somewhere safe. Expanding a row on the Exports tab shows the exact command to decrypt and read the file, which contains your log entries as gzip-compressed JSON Lines. Completed exports remain available to download for seven days, and a failed export can be retried with the same filters in one click.

### Clearer policy compilation errors in playgrounds

Compilation problems in a playground are now reported where they actually occur. Each error is marked inline on the offending line in the editor, and the Problems panel shows its line and column alongside a fuller description, so you can click through to the exact source rather than hunting for it. Several classes of problem that were previously reported vaguely — or not at all — are now surfaced properly, including invalid expressions in conditions, undefined or redefined variables and constants, unknown and ambiguous derived roles, and problems with scopes and imports. Where a diagnostic relates to a documented concept, it links straight to the relevant Cerbos policy documentation.

### Schema validation errors shown in playgrounds

If a principal or resource fixture does not satisfy the schema attached to your policy, the Explore tab now says so directly beneath the fixture selector. Previously a schema violation would quietly influence the outcome, leaving you to work out why a check did not behave as expected. Actions affected by the failure are left in an undetermined state until the error is resolved, making it clear that the result is a fixture problem rather than a policy decision, and validation errors on the request itself are reported the same way above the action results.

---

This PR also adds supporting documentation for the above:

- **Audit log collection** — a new *Exporting logs* section covering how to start an export, how the age encryption keys work, the Exports tab and its statuses, decrypting and reading the downloaded file, and the seven-day retention on exported files.
- **User management** — an *Export audit logs* row in the workspace roles permissions matrix.
- **Playgrounds** — a new *Schema validation* section under the Explore tab, and a new *Problems* section under Test results describing the compilation diagnostics and the categories of problem they cover.
