### PR TITLE
Hub docs: network requirements, remove phantom offline mode, fix audit mask timing

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -35,6 +35,7 @@
 *** xref:policy-stores-cli-homebrew.adoc[Homebrew]
 *** xref:policy-stores-cli-npx.adoc[npx]
 ** xref:policy-stores-upload.adoc[Browser upload]
+** xref:policy-stores-file-rules.adoc[File rules and limits]
 * xref:deployments.adoc[Deployments]
 * Policy Decision Points (PDPs)
 ** xref:decision-points.adoc[Service]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -4,6 +4,8 @@
 * xref:synapse:ROOT:index.adoc[Cerbos Synapse]
 * https://www.cerbos.dev/ecosystem[Cerbos integrations]
 
+//-
+
 * xref:index.adoc[Introduction]
 * xref:concepts.adoc[Concepts]
 * xref:playground.adoc[Playgrounds]

--- a/modules/ROOT/pages/audit-log-collection.adoc
+++ b/modules/ROOT/pages/audit-log-collection.adoc
@@ -161,7 +161,7 @@ Expand a row to see the time range and filters the export was created with, the 
 
 === Downloading and decrypting
 
-The downloaded file is age-encrypted and gzip-compressed, and contains the exported entries as JSON Lines — one JSON object per log entry. To decrypt and read it, save your secret key as `age.key` and run:
+The downloaded file is age-encrypted and gzip-compressed, and contains the exported entries as JSON Lines, one JSON object per log entry. To decrypt and read it, save your secret key as `age.key` and run:
 
 [source,sh]
 ----
@@ -172,7 +172,7 @@ Because the output is JSON Lines, it can be piped directly into tools such as `j
 
 === Retention
 
-Completed exports remain available to download for seven days from the time they were generated. After that, the file is deleted and the export is marked as expired. Expiry applies only to the exported file — the underlying audit log data is unaffected and continues to be retained according to your plan, so the export can be re-created as long as the entries are still within that retention period.
+Completed exports remain available to download for seven days from the time they were generated. After that, the file is deleted and the export is marked as expired. Expiry applies only to the exported file; the underlying audit log data is unaffected and continues to be retained according to your plan, so the export can be re-created as long as the entries are still within that retention period.
 
 == Masking sensitive fields
 

--- a/modules/ROOT/pages/audit-log-collection.adoc
+++ b/modules/ROOT/pages/audit-log-collection.adoc
@@ -166,7 +166,7 @@ audit:
 
 TIP: Use the xref:cerbos:configuration:audit.adoc#local[`local` audit backend] along with xref:cerbos:cli:cerbosctl.adoc#audit[cerbosctl audit commands] to inspect your audit logs locally and determine the paths that need to be masked.
 
-CAUTION: In order to avoid slowing down request processing and to avoid any data losses, raw log entries are stored locally on disk at the storage path. The masks are applied later by the background process that syncs the on-disk log entries to Cerbos Hub. To avoid storing authentication tokens and other sensitive request parameters locally, use the top-level `includeMetadataKeys` and `excludeMetadataKeys` settings. Refer to xref:cerbos:configuration:audit.adoc[Cerbos audit configuration] for more details.
+NOTE: Masks are applied before each entry is written to the local buffer on disk, so masked fields are neither stored locally nor transmitted to Cerbos Hub. To drop whole metadata keys such as authentication tokens, rather than mask specific field paths, use the top-level `includeMetadataKeys` and `excludeMetadataKeys` settings. Refer to xref:cerbos:configuration:audit.adoc[Cerbos audit configuration] for more details.
 
 == Data storage
 

--- a/modules/ROOT/pages/decision-points.adoc
+++ b/modules/ROOT/pages/decision-points.adoc
@@ -234,7 +234,7 @@ storage:
       cacheDir: /var/cerbos/hub # Directory to cache downloaded bundles
 ----
 
-Mount a persistent volume at this path when running in containers or Kubernetes.
+Mount a persistent volume at this path when running in containers or Kubernetes. Caching avoids re-downloading an unchanged bundle on restart. It does not enable an offline start: a PDP still contacts Cerbos Hub at startup to fetch its bundle, and fails to start if Hub cannot be reached. See xref:reliability.adoc[Reliability] for network requirements and connectivity monitoring.
 
 === Fallback to git
 

--- a/modules/ROOT/pages/decision-points.adoc
+++ b/modules/ROOT/pages/decision-points.adoc
@@ -10,7 +10,7 @@ With Cerbos Hub:
 
 [horizontal]
 Pre-compiled bundles:: Policies are compiled once by Cerbos Hub and pushed as optimized bundles. PDPs skip parsing and compilation entirely, reducing startup time and memory usage.
-Instant fleet-wide updates:: Push-based distribution means all PDPs receive updates within seconds—no polling delays or staggered rollouts.
+Instant fleet-wide updates:: Push-based distribution means all PDPs receive updates within seconds, with no polling delays or staggered rollouts.
 Validated before deployment:: Policies are tested automatically before distribution. Failed tests block deployment, preventing broken policies from reaching production.
 Centralized visibility:: Monitor all connected PDPs from a single dashboard. See which version each instance is running, when it last connected, and access its audit logs.
 Built-in resilience:: PDPs cache bundles locally and continue operating if the Cerbos Hub API is temporarily unavailable. New instances can start immediately using bundles served from a CDN, independent of the API.
@@ -35,7 +35,7 @@ Service PDPs handle thousands of authorization checks per second. The compiled p
 
 === Data-sensitive environments
 
-All authorization data stays within your network. Cerbos Hub only pushes policy bundles—your request data, principal attributes, and resource attributes never leave your infrastructure.
+All authorization data stays within your network. Cerbos Hub only pushes policy bundles; your request data, principal attributes, and resource attributes never leave your infrastructure.
 
 == How it works
 
@@ -156,7 +156,7 @@ To generate client credentials:
 . Select the **Client credentials** tab
 . Click **Generate a client credential**
 . Choose **Read only** for PDPs that only need to receive bundles
-. Save the client secret—it cannot be recovered after creation
+. Save the client secret; it cannot be recovered after creation
 
 == Production deployment
 

--- a/modules/ROOT/pages/decision-points.adoc
+++ b/modules/ROOT/pages/decision-points.adoc
@@ -236,21 +236,6 @@ storage:
 
 Mount a persistent volume at this path when running in containers or Kubernetes.
 
-=== Offline mode
-
-In disaster recovery scenarios, start the PDP with the cached bundle:
-
-[source,shell]
-----
-docker run --rm --name cerbos \
-  -p 3592:3592 -p 3593:3593 \
-  -e CERBOS_HUB_OFFLINE=true \
-  -v /var/cerbos/hub:/var/cerbos/hub \
-  ghcr.io/cerbos/cerbos:latest server --config=/conf/.cerbos.yaml
-----
-
-The PDP loads the cached bundle and serves requests without connecting to Cerbos Hub.
-
 === Fallback to git
 
 As a last resort, switch the PDP to use the git storage driver and read policies directly from your policy repository:

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -2,6 +2,8 @@
 
 Cerbos Hub is an end-to-end authorization platform comprising a policy control plane, a data enrichment layer, and a distributed policy engine. It covers the full authorization lifecycle: authoring, testing, versioning, distribution, data enrichment, decision evaluation, and audit.
 
+https://hub.cerbos.cloud?utm_campaign=brand_cerbos&utm_source=documentation&utm_medium=text&utm_content=hub_docs_index[Sign up for Cerbos Hub] to create an organization and its first workspace, then follow the xref:getting-started.adoc[quick start guide] to connect a policy store and a PDP.
+
 == Platform components
 
 [cols="1,3"]
@@ -24,14 +26,14 @@ Cerbos Hub is an end-to-end authorization platform comprising a policy control p
 == Cerbos Hub features
 
 [unordered.stack]
-Collaborative policy editing:: Cerbos Hub playgrounds provide private, collaborative, IDE-like development environments to help author and test policies with ease. Drag and drop policy and test files directly into the playground editor for fast loading and testing.
-Managed build and release pipeline:: Cerbos Hub automatically validates, tests, signs, and distributes every policy change, giving you a turnkey CI/CD pipeline without extra infrastructure. Policy execution traces are available for debugging complex authorization logic, showing a step-by-step view of how requests are evaluated.
-Source agnostic policy stores:: Populate policy stores from any source using any of the many integration methods available.
-Coordinated rollout of policy changes:: Cerbos Hub pushes new policy bundles to every connected PDP instance, ensuring fleet-wide consistency and eliminating manual polling or reload logic.
-PDP monitoring:: Cerbos Hub shows which policies each PDP is serving, the exact bundle version, and when the instance was last seen.
-Embedded policy decision points:: Evaluate policies locally in browsers, edge functions, and other JavaScript environments using WebAssembly. Configure multiple ePDP rules per deployment, each with independent policy filtering (by resource, action, scope, role, or version), authentication requirements, and IP allowlists. Dynamic scopes enable per-tenant bundles in multi-tenant applications.
-Audit log aggregation:: With one line of configuration you can stream PDP decision logs to Cerbos Hub, filter sensitive fields locally, and retain searchable history without running a separate log stack.
-Organization usage dashboard:: The organization-level usage dashboard aggregates metrics from all your workspaces, providing a unified view of request volumes, policy distribution, and usage trends across your organization.
+xref:playground.adoc[Collaborative policy editing]:: Cerbos Hub playgrounds provide private, collaborative, IDE-like development environments to help author and test policies with ease. Drag and drop policy and test files directly into the playground editor for fast loading and testing.
+xref:deployments.adoc[Managed build and release pipeline]:: Cerbos Hub automatically validates, tests, signs, and distributes every policy change, giving you a turnkey CI/CD pipeline without extra infrastructure. Policy execution traces are available for debugging complex authorization logic, showing a step-by-step view of how requests are evaluated.
+xref:policy-stores.adoc[Source agnostic policy stores]:: Populate policy stores from any source using any of the many integration methods available.
+xref:deployments.adoc[Coordinated rollout of policy changes]:: Cerbos Hub pushes new policy bundles to every connected PDP instance, ensuring fleet-wide consistency and eliminating manual polling or reload logic.
+xref:decision-points.adoc[PDP monitoring]:: Cerbos Hub shows which policies each PDP is serving, the exact bundle version, and when the instance was last seen.
+xref:deployments-epdp-rules.adoc[Embedded policy decision points]:: Evaluate policies locally in browsers, edge functions, and other JavaScript environments using WebAssembly. Configure multiple ePDP rules per deployment, each with independent policy filtering (by resource, action, scope, role, or version), authentication requirements, and IP allowlists. Dynamic scopes enable per-tenant bundles in multi-tenant applications.
+xref:audit-log-collection.adoc[Audit log aggregation]:: With one line of configuration you can stream PDP decision logs to Cerbos Hub, filter sensitive fields locally, and retain searchable history without running a separate log stack.
+xref:usage-dashboard.adoc[Organization usage dashboard]:: The organization-level usage dashboard aggregates metrics from all your workspaces, providing a unified view of request volumes, policy distribution, and usage trends across your organization.
 
 == Cerbos Hub and open source Cerbos
 

--- a/modules/ROOT/pages/playground.adoc
+++ b/modules/ROOT/pages/playground.adoc
@@ -75,7 +75,7 @@ Click **+ Add action** to test additional actions, or **Create auxiliary data fi
 
 If your policies reference xref:cerbos:policies:schemas.adoc[schemas], the principal and resource you select are validated against them when the request is evaluated. Any violation is reported in an alert directly beneath the relevant fixture selector, listing the attribute paths that failed and why. Validation problems with the request as a whole are reported the same way, above the list of actions.
 
-While a validation error is outstanding, every action is shown in an undetermined state rather than as `ALLOW` or `DENY`. This distinguishes a request that could not be meaningfully evaluated from one that was genuinely denied, which is easy to misread otherwise. Correct the fixture, or adjust the schema, and the effects are recalculated immediately.
+While a validation error is outstanding, every action is shown in an undetermined state rather than as `ALLOW` or `DENY`. This distinguishes a request that could not be evaluated from one that was denied. Correct the fixture, or adjust the schema, and the effects are recalculated immediately.
 
 === Permissions matrix view
 
@@ -100,7 +100,7 @@ Click on any test file to see detailed results. For failed tests, a side-by-side
 
 The Problems tab lists everything that prevented your policies from compiling, grouped by file. Each entry gives the kind of error, the line and column it occurred at, and a description of what went wrong. Click an entry to jump straight to that position in the editor, where the same errors are also marked inline on the offending lines.
 
-Diagnostics cover the full range of compilation failures, not just malformed YAML:
+Diagnostics cover the full range of compilation failures, not only malformed YAML:
 
 * Invalid xref:cerbos:policies:conditions.adoc[condition expressions], including expressions that parse but fail to compile.
 * Undefined, redefined, cyclical, or invalidly named xref:cerbos:policies:variables.adoc#variables[variables] and xref:cerbos:policies:variables.adoc#constants[constants].

--- a/modules/ROOT/pages/policy-stores-file-rules.adoc
+++ b/modules/ROOT/pages/policy-stores-file-rules.adoc
@@ -1,0 +1,79 @@
+= Policy stores: file rules and limits
+
+A policy store accepts a specific set of files and enforces size and count limits. A real policy repository usually also contains CI configuration, documentation, and hidden files, so this page defines exactly what a store accepts and how the upload commands behave, so uploads are predictable rather than discovered through failures.
+
+== Accepted files
+
+Every file is checked against these rules when you upload:
+
+[unordered.stack]
+Extensions:: Only `.json`, `.yaml`, and `.yml` are accepted (the check is case-insensitive). Any other extension is unsupported: a `README.md`, `Makefile`, or `.go` file is not a store file.
+Hidden paths:: Any path with a component beginning with a dot is rejected, so `.git/`, `.github/`, and files such as `.gitlab-ci.yml` never enter the store.
+Schemas:: Files under `_schemas/` must be JSON. A YAML file under `_schemas/` is rejected.
+Test data:: Files under `testdata/` must be named `principals`, `resources`, or `auxdata` (the spellings `auxData` and `aux_data` are also accepted), with any accepted extension. Any other filename under `testdata/` is rejected.
+
+[NOTE]
+====
+There is no `.cerbosignore` or ignore-file mechanism. Filtering is exactly the extension, hidden-path, `_schemas`, and `testdata` rules above.
+====
+
+== Tests and the runtime bundle
+
+Keep tests and test data in the store alongside the policies they exercise. Test suites and `testdata/` fixtures are first-class store content, and Cerbos Hub runs them automatically. Two things are worth knowing:
+
+* *Tests run when a deployment builds a bundle, not when you upload.* Upload validates only that each file parses as a policy, schema, test suite, or fixture. The suites are executed later, when a deployment that references the store builds a bundle. A failing test blocks that bundle, and the previously built bundle stays active.
+* *Test files never reach the runtime bundle.* The bundle builder excludes test suites and `testdata/`, so including them in the store costs nothing at runtime and you do not need to strip them before uploading.
+
+== Uploading with the CLI
+
+The `cerbosctl hub store` commands operate on a store's files:
+
+[cols="1m,3",options="header"]
+|===
+| Command | Purpose
+
+| upload-git | Upload the files from a local Git working tree, attaching its commit details.
+| replace-files | Overwrite the whole store with the given set of files.
+| add-files | Add or update specific files.
+| delete-files | Remove specific files.
+| get-files | Download specific files.
+| list-files | List the files in the store.
+| download | Download the entire store.
+|===
+
+`replace-files` accepts a directory, a `.zip` archive, or `-` to read a zip from standard input:
+
+[source,sh]
+----
+cerbosctl hub store replace-files ./policies
+cerbosctl hub store replace-files policies.zip
+cat policies.zip | cerbosctl hub store replace-files -
+----
+
+Given a directory, `replace-files` zips the entire tree and uploads it, and the store classifies and filters the files on receipt. `add-files` instead filters as it walks the directory, dropping hidden and unsupported files before upload.
+
+=== How uploads handle rejected files
+
+The two bulk commands differ in how they treat a file that breaks a rule:
+
+[unordered.stack]
+replace-files:: A file with an unsupported extension, a hidden path, or a bad `testdata`/`_schemas` name is *skipped* and returned in an ignored-files list. The upload fails only when no usable files remain (`no usable files`). This makes it safe to point at a whole repository.
+add-files:: A rejected file fails the *entire batch*, and nothing is uploaded.
+
+A file that is otherwise valid but has invalid *contents* (a malformed policy, an invalid schema, or an invalid test suite, reported as `test suite is invalid`) is a hard failure in both commands. Content errors are never skipped.
+
+== Limits
+
+Uploads are bounded by these limits:
+
+[cols="2,1,3",options="header"]
+|===
+| Limit | Value | Applies to
+
+| Zipped upload size | 15 MiB | `replace-files`
+| File size | 5 MiB | every file
+| Total extracted size | 50 MiB | a `replace-files` archive
+| Path length | 1024 characters | every file path
+| Operations per batch | 25 | `add-files`, `delete-files`
+| Files per request | 10 | `get-files`
+|===

--- a/modules/ROOT/pages/policy-stores-file-rules.adoc
+++ b/modules/ROOT/pages/policy-stores-file-rules.adoc
@@ -1,6 +1,6 @@
 = Policy stores: file rules and limits
 
-A policy store accepts a specific set of files and enforces size and count limits. A real policy repository usually also contains CI configuration, documentation, and hidden files, so this page defines exactly what a store accepts and how the upload commands behave, so uploads are predictable rather than discovered through failures.
+A policy store accepts only certain files and enforces size and count limits. A real policy repository usually also contains CI configuration, documentation, and hidden files, so this page sets out what a store accepts, how the upload commands behave, and the limits that apply.
 
 == Accepted files
 

--- a/modules/ROOT/pages/policy-stores-file-rules.adoc
+++ b/modules/ROOT/pages/policy-stores-file-rules.adoc
@@ -1,6 +1,6 @@
 = Policy stores: file rules and limits
 
-A policy store accepts only certain files and enforces size and count limits. A real policy repository usually also contains CI configuration, documentation, and hidden files, so this page sets out what a store accepts, how the upload commands behave, and the limits that apply.
+A policy store accepts only policy, schema, test suite, and test data files, and enforces size and count limits on every upload. The other files a policy repository ordinarily contains, such as CI configuration, documentation, and hidden files, are rejected or skipped according to the rules below.
 
 == Accepted files
 
@@ -11,15 +11,17 @@ Extensions:: Only `.json`, `.yaml`, and `.yml` are accepted (the check is case-i
 Hidden paths:: Any path with a component beginning with a dot is rejected, so `.git/`, `.github/`, and files such as `.gitlab-ci.yml` never enter the store.
 Schemas:: Files under `_schemas/` must be JSON. A YAML file under `_schemas/` is rejected.
 Test data:: Files under `testdata/` must be named `principals`, `resources`, or `auxdata` (the spellings `auxData` and `aux_data` are also accepted), with any accepted extension. Any other filename under `testdata/` is rejected.
+Test suites:: A file whose name ends in `_test` before the extension, such as `album_test.yaml`, is a test suite.
+Policies:: Every other accepted file is a policy. A test suite named `tests.yaml` is therefore read as a policy and rejected as malformed.
 
 [NOTE]
 ====
-There is no `.cerbosignore` or ignore-file mechanism. Filtering is exactly the extension, hidden-path, `_schemas`, and `testdata` rules above.
+There is no `.cerbosignore` or ignore-file mechanism. A file is accepted or rejected by exactly the rules above.
 ====
 
 == Tests and the runtime bundle
 
-Keep tests and test data in the store alongside the policies they exercise. Test suites and `testdata/` fixtures are first-class store content, and Cerbos Hub runs them automatically. Two things are worth knowing:
+Keep tests and test data in the store alongside the policies they exercise. Test suites and `testdata/` fixtures are first-class store content, and Cerbos Hub runs them automatically.
 
 * *Tests run when a deployment builds a bundle, not when you upload.* Upload validates only that each file parses as a policy, schema, test suite, or fixture. The suites are executed later, when a deployment that references the store builds a bundle. A failing test blocks that bundle, and the previously built bundle stays active.
 * *Test files never reach the runtime bundle.* The bundle builder excludes test suites and `testdata/`, so including them in the store costs nothing at runtime and you do not need to strip them before uploading.
@@ -32,7 +34,7 @@ The `cerbosctl hub store` commands operate on a store's files:
 |===
 | Command | Purpose
 
-| upload-git | Upload the files from a local Git working tree, attaching its commit details.
+| upload-git | Apply the file changes between two commits of a local Git repository.
 | replace-files | Overwrite the whole store with the given set of files.
 | add-files | Add or update specific files.
 | delete-files | Remove specific files.
@@ -40,6 +42,8 @@ The `cerbosctl hub store` commands operate on a store's files:
 | list-files | List the files in the store.
 | download | Download the entire store.
 |===
+
+`upload-git` works from committed history, not the working tree, so uncommitted edits are never uploaded. With no arguments it applies the changes between the commit recorded in the store's current version and `HEAD`, and records the new commit details in the store. Use `--from` and `--to` to select an explicit commit range. When the store has no recorded commit details, `upload-git` replaces the store with the files at the target commit instead.
 
 `replace-files` accepts a directory, a `.zip` archive, or `-` to read a zip from standard input:
 
@@ -58,7 +62,7 @@ The two bulk commands differ in how they treat a file that breaks a rule:
 
 [unordered.stack]
 replace-files:: A file with an unsupported extension, a hidden path, or a bad `testdata`/`_schemas` name is *skipped* and returned in an ignored-files list. The upload fails only when no usable files remain (`no usable files`). This makes it safe to point at a whole repository.
-add-files:: A rejected file fails the *entire batch*, and nothing is uploaded.
+add-files:: A rejected file fails the *entire batch*, and nothing is uploaded. The exception is the directory walk described above: hidden and unsupported files are dropped locally and never become part of the batch. Bad `testdata` and `_schemas` names are not checked locally, so they reach the API and do fail the batch.
 
 A file that is otherwise valid but has invalid *contents* (a malformed policy, an invalid schema, or an invalid test suite, reported as `test suite is invalid`) is a hard failure in both commands. Content errors are never skipped.
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -2,27 +2,25 @@
 
 == 2026-08-11
 
-[#_2026_08_11]
-
 === Export audit logs from Cerbos Hub
 
 [#_audit_log_exports]
 
 You can now take your decision and access logs out of Cerbos Hub for long-term archiving or analysis in your own tooling. Press *Export* on the xref:audit-log-collection.adoc#_exporting_logs[Audit logs] page and the export is queued in the background using the time range and filters you already have applied, so you get exactly the entries you were looking at. A new *Exports* tab lists every export with its status, the filters it used and its expiry date, and offers a download button as soon as it is ready. Exporting is available to workspace and organization Owners.
 
-Exports are encrypted with https://age-encryption.org[age] before they leave Cerbos Hub. You can supply your own public key, or let Cerbos Hub generate a key pair for you and save it when the export starts — the secret key is never retained by Cerbos Hub, so store it somewhere safe. Expanding a row on the Exports tab shows the exact command to decrypt and read the file, which contains your log entries as gzip-compressed JSON Lines. Completed exports remain available to download for seven days, and a failed export can be retried with the same filters in one click.
+Exports are encrypted with https://age-encryption.org[age] before they leave Cerbos Hub. You can supply your own public key, or let Cerbos Hub generate a key pair for you and save it when the export starts. The secret key is never retained by Cerbos Hub, so store it somewhere safe. Expanding a row on the Exports tab shows the exact command to decrypt and read the file, which contains your log entries as gzip-compressed JSON Lines. Completed exports remain available to download for seven days, and a failed export can be retried with the same filters in one click.
 
 === Clearer policy compilation errors in playgrounds
 
 [#_playground_compile_diagnostics]
 
-Compilation problems in a xref:playground.adoc[playground] are now reported where they actually occur. Each error is marked inline on the offending line in the editor, and the xref:playground.adoc#_problems[Problems] panel shows its line and column alongside a fuller description, so you can click through to the exact source rather than hunting for it. Several classes of problem that were previously reported vaguely — or not at all — are now surfaced properly, including invalid expressions in conditions, undefined or redefined variables and constants, unknown and ambiguous derived roles, and problems with scopes and imports. Where a diagnostic relates to a documented concept, it links straight to the relevant Cerbos policy documentation.
+Compilation problems in a xref:playground.adoc[playground] are now reported where they actually occur. Each error is marked inline on the offending line in the editor, and the xref:playground.adoc#_problems[Problems] panel shows its line and column alongside a fuller description, so you can click through to the exact source rather than hunting for it. Several classes of problem that were previously reported vaguely, or not at all, are now surfaced properly. These include invalid expressions in conditions, undefined or redefined variables and constants, unknown and ambiguous derived roles, and problems with scopes and imports. Where a diagnostic relates to a documented concept, it links straight to the relevant Cerbos policy documentation.
 
 === Schema validation errors shown in playgrounds
 
 [#_playground_schema_validation]
 
-If a principal or resource fixture does not satisfy the schema attached to your policy, the xref:playground.adoc#_schema_validation[Explore tab] now says so directly beneath the fixture selector. Previously a schema violation would quietly influence the outcome, leaving you to work out why a check did not behave as expected. Actions affected by the failure are left in an undetermined state until the error is resolved, making it clear that the result is a fixture problem rather than a policy decision, and validation errors on the request itself are reported the same way above the action results.
+If a principal or resource fixture does not satisfy the schema attached to your policy, the xref:playground.adoc#_schema_validation[Explore tab] now says so directly beneath the fixture selector. Previously a schema violation would quietly influence the outcome, leaving you to work out why a check did not behave as expected. Actions affected by the failure are left in an undetermined state until the error is resolved, making it clear that the result is a fixture problem rather than a policy decision. Validation errors on the request itself are reported the same way, above the action results.
 
 == 2026-07-27
 

--- a/modules/ROOT/pages/reliability.adoc
+++ b/modules/ROOT/pages/reliability.adoc
@@ -17,10 +17,10 @@ PDPs reach Cerbos Hub over outbound HTTPS on port 443. Allow these hosts through
 
 | cdn.cerbos.cloud
 | 443
-| Bootstrap bundle download at startup. Plain HTTPS.
+| All bundle content downloads: the bootstrap bundle at startup, and every bundle delivered by a subsequent policy update. Plain HTTPS.
 |===
 
-All connections to Cerbos Hub require TLS 1.3; a proxy that downgrades below TLS 1.3 is refused. The PDP honours the standard `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables.
+All connections to Cerbos Hub require TLS 1.3; a proxy that downgrades below TLS 1.3 is refused. The PDP honors the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
 
 == Push-based updates
 

--- a/modules/ROOT/pages/reliability.adoc
+++ b/modules/ROOT/pages/reliability.adoc
@@ -2,6 +2,30 @@
 
 Cerbos Hub is designed for high availability. All PDPs continue to operate independently even when Cerbos Hub experiences disruptions.
 
+[#network-requirements]
+== Network requirements
+
+PDPs reach Cerbos Hub over outbound HTTPS on port 443. Allow these hosts through any egress proxy or firewall:
+
+[cols="2m,1,4",options="header"]
+|===
+| Host | Port | Purpose
+
+| api.cerbos.cloud
+| 443
+| Bundle update stream and audit log ingest. Uses the Connect protocol over HTTP/2; the update stream is a long-lived HTTP/2 stream.
+
+| cdn.cerbos.cloud
+| 443
+| Bootstrap bundle download at startup. Plain HTTPS.
+
+| distribution.cerbos.cloud
+| 443
+| Container image pulls (the Cerbos and Synapse images). Needed only where images are pulled, not by the running PDP.
+|===
+
+All connections to Cerbos Hub require TLS 1.3; a proxy that downgrades below TLS 1.3 is refused. The PDP honours the standard `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables.
+
 == Push-based updates
 
 When a PDP connects to Cerbos Hub, it establishes a two-way communication channel used to receive the initial policy bundle and subsequent update notifications. Because there is no polling, all PDPs converge on the same policy version within seconds of a change.
@@ -28,22 +52,7 @@ storage:
       cacheDir: /var/cerbos/hub # Directory to cache downloaded bundles
 ----
 
-Mount a persistent volume at this path when running in containers or Kubernetes. Cached bundles allow PDPs to restart without network access to Cerbos Hub.
-
-== Offline mode
-
-In disaster recovery scenarios, start the PDP with only the cached bundle:
-
-[source,shell]
-----
-docker run --rm --name cerbos \
-  -p 3592:3592 -p 3593:3593 \
-  -e CERBOS_HUB_OFFLINE=true \
-  -v /var/cerbos/hub:/var/cerbos/hub \
-  ghcr.io/cerbos/cerbos:latest server --config=/conf/.cerbos.yaml
-----
-
-The PDP loads the cached bundle and serves requests without connecting to Cerbos Hub.
+Mount a persistent volume at this path when running in containers or Kubernetes. Caching avoids re-downloading an unchanged bundle on restart. It does not enable an offline start: a PDP still contacts Cerbos Hub at startup to fetch its bundle, and fails to start if Hub cannot be reached.
 
 == Fallback to git
 

--- a/modules/ROOT/pages/reliability.adoc
+++ b/modules/ROOT/pages/reliability.adoc
@@ -18,10 +18,6 @@ PDPs reach Cerbos Hub over outbound HTTPS on port 443. Allow these hosts through
 | cdn.cerbos.cloud
 | 443
 | Bootstrap bundle download at startup. Plain HTTPS.
-
-| distribution.cerbos.cloud
-| 443
-| Container image pulls (the Cerbos and Synapse images). Needed only where images are pulled, not by the running PDP.
 |===
 
 All connections to Cerbos Hub require TLS 1.3; a proxy that downgrades below TLS 1.3 is refused. The PDP honours the standard `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables.

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -11,7 +11,7 @@
 [horizontal]
 Invalid credentials:: Verify the client ID and client secret are correct. Generate new credentials from the deployment's **Client credentials** tab if needed.
 Wrong deployment ID:: Confirm the deployment ID matches the deployment you want to connect to. Find the ID on the deployment detail page.
-Network restrictions:: Ensure outbound HTTPS (port 443) is allowed to the Cerbos Hub hosts (`api.cerbos.cloud` and `cdn.cerbos.cloud`) — see xref:reliability.adoc#network-requirements[Network requirements]. Check firewalls, security groups, and network policies.
+Network restrictions:: Ensure outbound HTTPS (port 443) is allowed to the Cerbos Hub hosts (`api.cerbos.cloud` and `cdn.cerbos.cloud`); see xref:reliability.adoc#network-requirements[Network requirements]. Check firewalls, security groups, and network policies.
 Expired credentials:: Client credentials do not expire, but they can be revoked. Check the credential status in Cerbos Hub.
 
 === PDP shows as disconnected in Cerbos Hub

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -11,7 +11,7 @@
 [horizontal]
 Invalid credentials:: Verify the client ID and client secret are correct. Generate new credentials from the deployment's **Client credentials** tab if needed.
 Wrong deployment ID:: Confirm the deployment ID matches the deployment you want to connect to. Find the ID on the deployment detail page.
-Network restrictions:: Ensure outbound HTTPS (port 443) is allowed to Cerbos Hub endpoints. Check firewalls, security groups, and network policies.
+Network restrictions:: Ensure outbound HTTPS (port 443) is allowed to the Cerbos Hub hosts (`api.cerbos.cloud` and `cdn.cerbos.cloud`) — see xref:reliability.adoc#network-requirements[Network requirements]. Check firewalls, security groups, and network policies.
 Expired credentials:: Client credentials do not expire, but they can be revoked. Check the credential status in Cerbos Hub.
 
 === PDP shows as disconnected in Cerbos Hub


### PR DESCRIPTION
Corrections and additions to the Cerbos Hub docs, from verifying the T-Mobile POC findings against the `cerbos` and `spitfire` source.

**Networking (new)**
- `reliability.adoc`: add a **Network requirements** section naming the egress hosts the PDP dials — `api.cerbos.cloud` (bundle watch stream + audit ingest, Connect over HTTP/2), `cdn.cerbos.cloud` (bootstrap, plain HTTPS) — plus the TLS 1.3 floor and the honoured `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` vars. Verified against `internal/hub/conf.go` and `internal/hub/hub.go`.
- `troubleshooting.adoc`: name the hosts and link the new section instead of the bare "Cerbos Hub endpoints".

**Remove the phantom offline mode**
- `reliability.adoc` and `decision-points.adoc`: delete the "Offline mode" blocks documenting `CERBOS_HUB_OFFLINE=true`. **That env var exists in no codebase** — it is not read by `cerbos`, `spitfire`, or `cloud-api`.
- `reliability.adoc`: correct "Cached bundles allow PDPs to restart without network access" — the cache avoids a re-download but the PDP still contacts Hub at startup and fails fast if it can't (`internal/storage/hub/remote_source.go`).

**Audit mask timing**
- `audit-log-collection.adoc`: the CAUTION said masks are applied later by the background sync, so raw entries hit local disk first. Since v0.44.0 (PR #2558) the mask is applied on **write**, before the local buffer — masked fields are never stored locally. Corrected.

---

Closes cerbos/cerbos-private#2025 (removes the phantom `CERBOS_HUB_OFFLINE` offline mode and corrects the cache/startup wording).

Closes cerbos/cerbos-private#2029 — publishes the egress hosts, ports, TLS 1.3 floor and the HTTP/2 Connect stream. The connection/TLS/CA/retry config controls in that issue belong to the Cerbos PDP hub-driver docs and are not in this PR.

**Store file rules (added)**
- New `policy-stores-file-rules.adoc` page: accepted file extensions, hidden-path/`_schemas`/`testdata` rules, when tests run and what reaches the runtime bundle, the `cerbosctl hub store` commands (including `upload-git`), `replace-files` vs `add-files` failure semantics, and the size/count limits. Verified against the spitfire store backend and cerbosctl.

Closes cerbos/cerbos-private#2030.