### PR TITLE
Add Hub release notes and docs for deployment freeze and rollback

### DIFF
--- a/modules/ROOT/pages/deployments.adoc
+++ b/modules/ROOT/pages/deployments.adoc
@@ -18,7 +18,7 @@ Policies:: Browse the current policies included in this deployment and view thei
 Decision points:: See the PDPs currently connected to this deployment. Each PDP shows its ID, the build it's running, active sessions, Cerbos version, when it was last seen, and a link to its audit logs.
 Embedded PDP rules:: Configure xref:deployments-epdp-rules.adoc[embedded policy decision points] for this deployment. Each rule defines policy filtering criteria (resources, actions, scopes, roles, versions), authentication requirements, and IP allowlists. Multiple rules can serve different clients or environments from the same deployment.
 Client credentials:: Manage API credentials scoped to this deployment for PDP connections, audit log collection, and authenticated ePDP bundle access.
-Settings:: Configure deployment options including which policy stores contribute to builds.
+Settings:: Configure deployment options including which policy stores contribute to builds, and <<_freezing_and_rolling_back,freeze or unfreeze>> the deployment.
 
 == Deployed versions
 
@@ -29,6 +29,32 @@ Build reference:: A unique identifier for the build. Click to view detailed info
 Active from:: The timestamp when this build was activated and pushed to connected PDPs.
 Active to:: The timestamp when this build was replaced by a newer version, or a dash if it is the currently active build.
 Included policies:: The policy stores and specific versions that contributed to this build. This makes it easy to trace exactly which policies were in effect at any point in time.
+
+== Freezing and rolling back
+
+By default a deployment always tracks the latest build: every change to a contributing policy store produces a new bundle that is delivered to connected PDPs as soon as it compiles and passes its tests. Freezing a deployment suspends that, and rolling back lets you put an earlier version of your policies live.
+
+Both actions require the `Owner` or `Developer` role in the workspace. See xref:user-management.adoc[User management] for details.
+
+=== Freezing a deployment
+
+Open the deployment's Settings tab and choose *Freeze deployment*. The version that is currently live stays live, and policy changes pushed to the linked stores are no longer deployed to connected PDPs while the deployment is frozen.
+
+A frozen deployment is labelled *Frozen* in the workspace deployment list and on the deployment page itself, so it is clear why recent policy changes have not reached your PDPs.
+
+Choose *Unfreeze deployment* on the same tab to resume. The latest version of your policies is built and deployed to connected PDPs, replacing whatever was live — including a version that was pinned by a rollback.
+
+=== Rolling back to an earlier version
+
+Each row in the <<_deployed_versions,deployed versions>> table other than the live one carries an action:
+
+[unordered.stack]
+Roll back:: Shown for versions older than the one that is currently live. Use it to return to a known-good bundle after a bad policy change.
+Promote:: Shown for versions newer than the one that is currently live, which is the case when a rollback has left the deployment pinned to an older bundle.
+
+Selecting either deploys that version to connected PDPs immediately and freezes the deployment, so the version you picked stays live until you unfreeze it. This means a rollback will not be undone by the next policy change that lands in a contributing store.
+
+If someone else changes the same deployment while you have the page open, your action is rejected and the page refreshes so you can check the current state before trying again.
 
 == Browsing policies
 
@@ -78,6 +104,8 @@ Whenever Cerbos Hub detects a change in any policy store connected to a deployme
 . **Compilation**: Policies from all contributing stores are compiled together. If compilation fails, the error is surfaced so you can diagnose it quickly.
 . **Test execution**: After successful compilation, Cerbos Hub runs all policy tests found across the contributing stores. Failures are displayed with full logs for debugging.
 . **Bundle generation**: When compilation and tests pass, the bundle is generated and all PDPs assigned to this deployment receive a push notification to download and activate the new bundle immediately.
+
+NOTE: While a deployment is <<_freezing_and_rolling_back,frozen>>, changes to the contributing policy stores are not deployed and the version that is currently live stays in place. Unfreezing the deployment builds and deploys the latest version of your policies.
 
 == Workspace issues
 

--- a/modules/ROOT/pages/playground.adoc
+++ b/modules/ROOT/pages/playground.adoc
@@ -58,6 +58,8 @@ The playground engine settings in the Settings tab allow you to configure the xr
 
 - **Globals**: Global variables are a way to pass environment-specific information to policy conditions. Values defined here are exposed to policy conditions via the `globals` object.
 
+- **Strict evaluation**: By default, an error raised while evaluating a condition or a variable — referencing an attribute that is not there, or comparing incompatible types — leaves the expression unsatisfied and evaluation carries on, so a rule that should have denied an action can be skipped without you noticing. When strict evaluation is enabled, such errors deny the affected action instead. This setting applies to the <<_explore_tab,Explore tab>> and the <<_try_the_api,Try the API>> section only; test files control it per suite or per test case with `options.strictEvaluation`. See xref:cerbos:configuration:engine.adoc#strict_evaluation[strict evaluation] for details of how the deny is scoped.
+
 You can find full details of these settings in the xref:cerbos:configuration:engine.adoc[Cerbos configuration reference].
 
 == Explore tab

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -1,5 +1,17 @@
 = Release notes
 
+== 2026-08-25
+
+[#_2026_08_25]
+
+=== Freeze a deployment and roll back to an earlier version
+
+[#_freeze_and_rollback_deployments]
+
+You can now hold a xref:deployments.adoc#_freezing_and_rolling_back[deployment] on a known-good version of your policies instead of always tracking the latest build. Freezing a deployment from its *Settings* tab keeps whatever is currently live in place: policy changes pushed to the linked stores are no longer built and delivered to connected PDPs until you unfreeze it. Frozen deployments are labelled in the deployment list and on the deployment page itself, so it is clear at a glance why new changes are not going out.
+
+The list of deployed versions now also offers a *Roll back* action on any earlier version and a *Promote* action on any newer one. Either choice makes that version live on connected PDPs immediately and freezes the deployment, so the version you picked stays put until you decide to resume. Unfreezing builds and deploys the latest version of your policies again, replacing whatever was pinned. Both freezing and rolling back are available to workspace Owners and Developers.
+
 == 2026-08-17
 
 [#_2026_08_17]
@@ -11,6 +23,12 @@
 The Settings tab of a xref:playground.adoc#_playground_engine_settings[playground] now has a *Strict evaluation* toggle, mirroring the xref:cerbos:configuration:engine.adoc#strict_evaluation[same setting] on a PDP. By default, an error raised while evaluating a condition or a variable — referencing an attribute that is not there, or comparing incompatible types — simply leaves the expression unsatisfied and evaluation carries on, which means a rule that should have denied an action can be skipped without you noticing. With strict evaluation enabled, those errors deny the affected action instead, so a broken condition surfaces while you are still writing the policy.
 
 The toggle applies to the xref:playground.adoc#_explore_tab[Explore tab] and the xref:playground.adoc#_try_the_api[Try the API] section, so you can compare both behaviours against the same policies. Test files are not affected, because each test suite and test case carries its own `options.strictEvaluation` setting.
+
+=== Playground settings are no longer reset when a playground loads
+
+[#_playground_settings_persist]
+
+Settings you save on the Settings tab of a xref:playground.adoc#_playground_engine_settings[playground] — the default policy version, globals, lenient scope search, and strict evaluation — now survive reopening it. Previously the built-in defaults could be applied over the top of your saved values while the playground was loading, quietly reverting your configuration. Saved values now always win, and defaults are only filled in for settings you have never set.
 
 == 2026-08-12
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -1,6 +1,30 @@
 = Release notes
 
+== 2026-08-17
+
+[#_2026_08_17]
+
+=== Strict evaluation setting for playgrounds
+
+[#_playground_strict_evaluation]
+
+The Settings tab of a xref:playground.adoc#_playground_engine_settings[playground] now has a *Strict evaluation* toggle, mirroring the xref:cerbos:configuration:engine.adoc#strict_evaluation[same setting] on a PDP. By default, an error raised while evaluating a condition or a variable — referencing an attribute that is not there, or comparing incompatible types — simply leaves the expression unsatisfied and evaluation carries on, which means a rule that should have denied an action can be skipped without you noticing. With strict evaluation enabled, those errors deny the affected action instead, so a broken condition surfaces while you are still writing the policy.
+
+The toggle applies to the xref:playground.adoc#_explore_tab[Explore tab] and the xref:playground.adoc#_try_the_api[Try the API] section, so you can compare both behaviours against the same policies. Test files are not affected, because each test suite and test case carries its own `options.strictEvaluation` setting.
+
+== 2026-08-12
+
+[#_2026_08_12]
+
+=== Policy links in audit log entries open the right file
+
+[#_audit_log_policy_links]
+
+The policy names shown in the details of an xref:audit-log-collection.adoc[audit log] entry now link straight to that policy file in the deployment that made the decision, with the correct build already selected. Previously the link could land on the deployment's Policies tab without opening the file, leaving you to find it yourself.
+
 == 2026-08-11
+
+[#_2026_08_11]
 
 === Export audit logs from Cerbos Hub
 

--- a/modules/ROOT/pages/user-management.adoc
+++ b/modules/ROOT/pages/user-management.adoc
@@ -132,6 +132,12 @@ Permissions assigned at the organization level are inherited by all workspaces. 
 |❌
 |❌
 
+|Manage deployments
+|✅
+|✅
+|❌
+|❌
+
 |Reset encryption key
 |✅
 |❌


### PR DESCRIPTION
Adds Hub release notes for the following user-facing changes, plus supporting documentation on the Deployments and Playground pages.

## 2026-08-25

### Freeze a deployment and roll back to an earlier version

You can now hold a deployment on a known-good version of your policies instead of always tracking the latest build. Freezing a deployment from its **Settings** tab keeps whatever is currently live in place: policy changes pushed to the linked stores are no longer built and delivered to connected PDPs until you unfreeze it. Frozen deployments are labelled in the deployment list and on the deployment page itself, so it is clear at a glance why new changes are not going out.

The list of deployed versions now also offers a **Roll back** action on any earlier version and a **Promote** action on any newer one. Either choice makes that version live on connected PDPs immediately and freezes the deployment, so the version you picked stays put until you decide to resume. Unfreezing builds and deploys the latest version of your policies again, replacing whatever was pinned. Both freezing and rolling back are available to workspace Owners and Developers.

## 2026-08-17

### Strict evaluation setting for playgrounds

The Settings tab of a playground now has a **Strict evaluation** toggle, mirroring the same setting on a PDP. By default, an error raised while evaluating a condition or a variable leaves the expression unsatisfied and evaluation carries on, so a rule that would have denied an action is skipped. With strict evaluation enabled, those errors deny the affected action instead, so a broken condition surfaces while you are still writing the policy.

The toggle applies to the Explore tab and the Try the API section, so you can compare both behaviours against the same policies. Test files are not affected, because each test suite and test case carries its own `options.strictEvaluation` setting.

### Playground settings are no longer reset when a playground loads

Settings you save on the Settings tab of a playground (the default policy version, globals, lenient scope search, and strict evaluation) now survive reopening it. Previously the built-in defaults could be applied over the top of your saved values while the playground was loading, reverting your configuration. Saved values now take precedence, and defaults are only filled in for settings you have never set.

## 2026-08-12

### Policy links in audit log entries open the right file

The policy names shown in the details of an audit log entry now link straight to that policy file in the deployment that made the decision, with the correct build already selected. Previously the link could land on the deployment's Policies tab without opening the file, leaving you to find it yourself.

## Documentation

- **Deployments**: new *Freezing and rolling back* section covering freezing and unfreezing from the Settings tab, the *Roll back* and *Promote* actions on deployed versions, the roles required, and how a frozen deployment affects the build life cycle.
- **User management**: added the missing *Manage deployments*, *Manage policy stores*, and *View usage* rows to the workspace role table.
- **Playground**: documented the *Strict evaluation* engine setting.
