### PR TITLE
Documentation review pass on deployment freeze and rollback

### DIFF
--- a/modules/ROOT/pages/deployments.adoc
+++ b/modules/ROOT/pages/deployments.adoc
@@ -32,7 +32,7 @@ Included policies:: The policy stores and specific versions that contributed to 
 
 == Freezing and rolling back
 
-By default a deployment always tracks the latest build: every change to a contributing policy store produces a new bundle that is delivered to connected PDPs as soon as it compiles and passes its tests. Freezing a deployment suspends that, and rolling back lets you put an earlier version of your policies live.
+Freezing a deployment holds the live version in place and stops new builds reaching connected PDPs. Rolling back replaces the live version with an earlier build.
 
 Both actions require the `Owner` or `Developer` role in the workspace. See xref:user-management.adoc[User management] for details.
 
@@ -40,19 +40,19 @@ Both actions require the `Owner` or `Developer` role in the workspace. See xref:
 
 Open the deployment's Settings tab and choose *Freeze deployment*. The version that is currently live stays live, and policy changes pushed to the linked stores are no longer deployed to connected PDPs while the deployment is frozen.
 
-A frozen deployment is labelled *Frozen* in the workspace deployment list and on the deployment page itself, so it is clear why recent policy changes have not reached your PDPs.
+A frozen deployment is labelled *Frozen* in the workspace deployment list and on the deployment page itself.
 
-Choose *Unfreeze deployment* on the same tab to resume. The latest version of your policies is built and deployed to connected PDPs, replacing whatever was live — including a version that was pinned by a rollback.
+Choose *Unfreeze deployment* on the same tab to resume. The latest version of your policies is built and deployed to connected PDPs, replacing whatever was live, including a version that was pinned by a rollback.
 
 === Rolling back to an earlier version
 
 Each row in the <<_deployed_versions,deployed versions>> table other than the live one carries an action:
 
 [unordered.stack]
-Roll back:: Shown for versions older than the one that is currently live. Use it to return to a known-good bundle after a bad policy change.
-Promote:: Shown for versions newer than the one that is currently live, which is the case when a rollback has left the deployment pinned to an older bundle.
+Roll back:: Shown for versions older than the one that is currently live.
+Promote:: Shown for versions newer than the one that is currently live, which happens once a rollback has pinned the deployment to an older build.
 
-Selecting either deploys that version to connected PDPs immediately and freezes the deployment, so the version you picked stays live until you unfreeze it. This means a rollback will not be undone by the next policy change that lands in a contributing store.
+Selecting either deploys that version to connected PDPs immediately and freezes the deployment. The version you picked stays live until you unfreeze it, so a rollback is not undone by the next policy change that lands in a contributing store.
 
 If someone else changes the same deployment while you have the page open, your action is rejected and the page refreshes so you can check the current state before trying again.
 

--- a/modules/ROOT/pages/playground.adoc
+++ b/modules/ROOT/pages/playground.adoc
@@ -56,9 +56,9 @@ The playground engine settings in the Settings tab allow you to configure the xr
 
 - **Lenient scope search**: When lenient scope search is enabled, if a policy with scope `a.b.c` does not exist in the store, Cerbos will attempt to find scopes `a.b`, `a` and ```` in that order.
 
-- **Globals**: Global variables are a way to pass environment-specific information to policy conditions. Values defined here are exposed to policy conditions via the `globals` object.
+- **Strict evaluation**: By default, an error raised while evaluating a condition or a variable leaves the expression unsatisfied and evaluation carries on, so a rule that would have denied an action is skipped. Typical causes are referencing an attribute that is not present and comparing incompatible types. When strict evaluation is enabled, such errors deny the affected action instead. This setting applies only to the <<_explore_tab,Explore tab>> and the <<_try_the_api,Try the API>> section; test files control it per suite or per test case with `options.strictEvaluation`. See xref:cerbos:configuration:engine.adoc#strict_evaluation[strict evaluation] for details of how the deny is scoped.
 
-- **Strict evaluation**: By default, an error raised while evaluating a condition or a variable — referencing an attribute that is not there, or comparing incompatible types — leaves the expression unsatisfied and evaluation carries on, so a rule that should have denied an action can be skipped without you noticing. When strict evaluation is enabled, such errors deny the affected action instead. This setting applies to the <<_explore_tab,Explore tab>> and the <<_try_the_api,Try the API>> section only; test files control it per suite or per test case with `options.strictEvaluation`. See xref:cerbos:configuration:engine.adoc#strict_evaluation[strict evaluation] for details of how the deny is scoped.
+- **Globals**: Global variables are a way to pass environment-specific information to policy conditions. Values defined here are exposed to policy conditions via the `globals` object.
 
 You can find full details of these settings in the xref:cerbos:configuration:engine.adoc[Cerbos configuration reference].
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -2,8 +2,6 @@
 
 == 2026-08-25
 
-[#_2026_08_25]
-
 === Freeze a deployment and roll back to an earlier version
 
 [#_freeze_and_rollback_deployments]
@@ -13,8 +11,6 @@ You can now hold a xref:deployments.adoc#_freezing_and_rolling_back[deployment] 
 The list of deployed versions now also offers a *Roll back* action on any earlier version and a *Promote* action on any newer one. Either choice makes that version live on connected PDPs immediately and freezes the deployment, so the version you picked stays put until you decide to resume. Unfreezing builds and deploys the latest version of your policies again, replacing whatever was pinned. Both freezing and rolling back are available to workspace Owners and Developers.
 
 == 2026-08-17
-
-[#_2026_08_17]
 
 === Strict evaluation setting for playgrounds
 
@@ -32,8 +28,6 @@ Settings you save on the Settings tab of a xref:playground.adoc#_playground_engi
 
 == 2026-08-12
 
-[#_2026_08_12]
-
 === Policy links in audit log entries open the right file
 
 [#_audit_log_policy_links]
@@ -41,8 +35,6 @@ Settings you save on the Settings tab of a xref:playground.adoc#_playground_engi
 The policy names shown in the details of an xref:audit-log-collection.adoc[audit log] entry now link straight to that policy file in the deployment that made the decision, with the correct build already selected. Previously the link could land on the deployment's Policies tab without opening the file, leaving you to find it yourself.
 
 == 2026-08-11
-
-[#_2026_08_11]
 
 === Export audit logs from Cerbos Hub
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -20,7 +20,7 @@ The list of deployed versions now also offers a *Roll back* action on any earlie
 
 [#_playground_strict_evaluation]
 
-The Settings tab of a xref:playground.adoc#_playground_engine_settings[playground] now has a *Strict evaluation* toggle, mirroring the xref:cerbos:configuration:engine.adoc#strict_evaluation[same setting] on a PDP. By default, an error raised while evaluating a condition or a variable — referencing an attribute that is not there, or comparing incompatible types — simply leaves the expression unsatisfied and evaluation carries on, which means a rule that should have denied an action can be skipped without you noticing. With strict evaluation enabled, those errors deny the affected action instead, so a broken condition surfaces while you are still writing the policy.
+The Settings tab of a xref:playground.adoc#_playground_engine_settings[playground] now has a *Strict evaluation* toggle, mirroring the xref:cerbos:configuration:engine.adoc#strict_evaluation[same setting] on a PDP. By default, an error raised while evaluating a condition or a variable leaves the expression unsatisfied and evaluation carries on, so a rule that would have denied an action is skipped. With strict evaluation enabled, those errors deny the affected action instead, so a broken condition surfaces while you are still writing the policy.
 
 The toggle applies to the xref:playground.adoc#_explore_tab[Explore tab] and the xref:playground.adoc#_try_the_api[Try the API] section, so you can compare both behaviours against the same policies. Test files are not affected, because each test suite and test case carries its own `options.strictEvaluation` setting.
 
@@ -28,7 +28,7 @@ The toggle applies to the xref:playground.adoc#_explore_tab[Explore tab] and the
 
 [#_playground_settings_persist]
 
-Settings you save on the Settings tab of a xref:playground.adoc#_playground_engine_settings[playground] — the default policy version, globals, lenient scope search, and strict evaluation — now survive reopening it. Previously the built-in defaults could be applied over the top of your saved values while the playground was loading, quietly reverting your configuration. Saved values now always win, and defaults are only filled in for settings you have never set.
+Settings you save on the Settings tab of a xref:playground.adoc#_playground_engine_settings[playground] (the default policy version, globals, lenient scope search, and strict evaluation) now survive reopening it. Previously the built-in defaults could be applied over the top of your saved values while the playground was loading, reverting your configuration. Saved values now take precedence, and defaults are only filled in for settings you have never set.
 
 == 2026-08-12
 

--- a/modules/ROOT/pages/user-management.adoc
+++ b/modules/ROOT/pages/user-management.adoc
@@ -82,7 +82,7 @@ Organization roles, except for the `Member` role, apply to all workspaces within
 |✅
 |===
 
-== Workspace Roles
+== Workspace roles
 
 Permissions assigned at the organization level are inherited by all workspaces. Additionally, a user can be assigned specific roles within a workspace, potentially granting more permissions for that particular workspace only.
 
@@ -120,6 +120,12 @@ Permissions assigned at the organization level are inherited by all workspaces. 
 |✅
 |❌
 
+|View usage
+|✅
+|❌
+|✅
+|❌
+
 |Export audit logs
 |✅
 |❌
@@ -133,6 +139,12 @@ Permissions assigned at the organization level are inherited by all workspaces. 
 |❌
 
 |Manage deployments
+|✅
+|✅
+|❌
+|❌
+
+|Manage policy stores
 |✅
 |✅
 |❌


### PR DESCRIPTION
Follow-up to #61: a documentation review pass over the deployment freeze and rollback content, plus completion of the workspace role table.

## Deployments

- Opened the *Freezing and rolling back* section with the behaviour it owns instead of restating the build life cycle described earlier on the page.
- Tightened the *Roll back* and *Promote* definitions and removed an em dash and a redundant clause.

## Playground

- Moved the *Strict evaluation* bullet above *Globals* so the list matches the order of the settings in the Settings tab.
- Split the opening sentence and moved the example causes into their own sentence.

## User management

Added three workspace actions that were missing from the role table:

- *Manage deployments* (Owner, Developer)
- *Manage policy stores* (Owner, Developer)
- *View usage* (Owner, Analyst)

Also changed the *Workspace roles* heading to sentence case, matching *Organization roles* above it.

## Release notes

- Applied the same wording changes to the corresponding entries.
- Removed the `[#_YYYY_MM_DD]` anchors on the four most recent date headings. AsciiDoc already generates the same IDs for those headings, so the explicit anchors were duplicates that the build discarded with an `id assigned to section already in use` warning. The anchors still resolve, and the four warnings are gone. Older entries in the file have the same duplication and are left unchanged here.
